### PR TITLE
publish version 1.0.1

### DIFF
--- a/image_picker/pubspec.lock
+++ b/image_picker/pubspec.lock
@@ -247,10 +247,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_image_picker_ios
-      sha256: "49ec84323b85803b8f997ac540a3d3d01e12a7d881c170819a58de25bd2b0f5d"
+      sha256: "8d7e598201b86a55174fa1d3164a90b95c6a75a3d05f2a841266b53a1e25361f"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.1"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:


### PR DESCRIPTION
Version 1.0.0 was skipped and should not be used due to incorrect Podspec configuration.